### PR TITLE
Fixed bug when location permission is denied

### DIFF
--- a/src/main/resources/assets/src/map.js
+++ b/src/main/resources/assets/src/map.js
@@ -52,6 +52,10 @@ export class Map extends React.Component {
 export async function distance(address) {
     let origin = await getCurrentLocation();
 
+    if (origin == null) {
+        return null;
+    }
+
     const getDistanceMatrix = (service, data) => new Promise((resolve, reject) => {
         service.getDistanceMatrix(data, (response, status) => {
             if (status === 'OK') {
@@ -87,6 +91,8 @@ async function getCurrentLocation() {
                 };
 
                 resolve(origin);
+            }, () => {
+                resolve(null);
             });
         }
     });


### PR DESCRIPTION
Fixed a bug that froze the application if the location permission was denied. Now, it just removes the branch distance since we can't figure out location. Fixes #97. 